### PR TITLE
Add bilingual Privacy & Cookies policy page and language-aware footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1062,8 +1062,8 @@
       <div>© 2026 Opotek. All rights reserved.</div>
       <div>Designed and developed with <3 by Opotek.</div>
       <div class="small-links">
-        <a href="#">Privacy Policy</a>
-        <a href="#">Cookies Policy</a>
+        <a href="policy.html?lang=en#privacy">Privacy Policy</a>
+        <a href="policy.html?lang=en#cookies">Cookies Policy</a>
         <a href="legal.html">Disclaimer</a>
       </div>
     </footer>
@@ -1289,6 +1289,8 @@
       footerLinks[0].textContent = t.privacy;
       footerLinks[1].textContent = t.cookies;
       footerLinks[2].textContent = t.disclaimer;
+      footerLinks[0].href = `policy.html?lang=${lang}#privacy`;
+      footerLinks[1].href = `policy.html?lang=${lang}#cookies`;
 
       localStorage.setItem('opotekLang', lang);
     }

--- a/policy.html
+++ b/policy.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy & Cookies Policy | Opotek</title>
+  <meta name="description" content="Privacy Policy and Cookies Policy for Opotek services in Spanish and English." />
+  <style>
+    :root{--bg:#0a0a0a;--bg-alt:#111111;--card:#151515;--txt:#f7f7f7;--muted:#b4b4b4;--line:rgba(255,255,255,.08);--radius:18px;}
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--txt);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;line-height:1.6}
+    .nav{position:sticky;top:0;z-index:20;background:rgba(10,10,10,.95);border-bottom:1px solid var(--line)}
+    .nav-inner,.wrap{max-width:980px;margin:0 auto;padding:0 18px}
+    .nav-inner{min-height:72px;display:flex;align-items:center;justify-content:space-between;gap:14px}
+    .brand{display:flex;align-items:center;text-decoration:none}
+    .brand img{height:42px;width:auto;display:block}
+    .nav-actions{display:flex;gap:10px;align-items:center}
+    .btn,.lang-toggle{border:1px solid var(--line);border-radius:999px;color:var(--muted);text-decoration:none;background:transparent;padding:8px 12px;font-size:12px;letter-spacing:1px;text-transform:uppercase;cursor:pointer}
+    .btn:hover,.lang-toggle:hover{color:var(--txt);background:rgba(255,255,255,.03)}
+    .hero{padding:56px 0 28px;border-bottom:1px solid var(--line)}
+    h1{margin:0 0 10px;font-size:clamp(28px,4vw,44px);line-height:1.1}
+    .subtitle{margin:0;color:var(--muted)}
+    main.wrap{padding-top:28px;padding-bottom:60px}
+    .content-card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:24px}
+    .last-updated{background:var(--bg-alt);border:1px solid var(--line);border-radius:12px;padding:10px 12px;margin-bottom:20px;color:var(--muted);font-size:14px}
+    h2{margin-top:28px;margin-bottom:8px;font-size:24px}
+    h3{margin-top:18px;margin-bottom:6px;font-size:19px}
+    p,li{color:#dddddd}
+    ul{padding-left:20px}
+    .company-info{border-left:2px solid var(--line);padding-left:14px}
+    [data-lang]{display:none}
+    [data-lang].active{display:block}
+    .policy-nav{display:flex;gap:12px;flex-wrap:wrap;margin-top:14px}
+    .policy-nav a{color:var(--muted);text-decoration:none;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:12px;letter-spacing:.4px}
+    .policy-nav a:hover{color:var(--txt)}
+    footer{border-top:1px solid var(--line);padding:20px 0 35px;color:var(--muted);font-size:13px}
+  </style>
+</head>
+<body>
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html" aria-label="Opotek home"><img src="img/LOGO_PNG_INV.png" alt="Opotek logo" /></a>
+      <div class="nav-actions">
+        <a class="btn" href="index.html" id="backHome">Home</a>
+        <button class="lang-toggle" id="languageToggle" type="button">ES</button>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="wrap" data-lang="en">
+      <h1>Privacy & Cookies Policy</h1>
+      <p class="subtitle">Opotek — Electronics Engineering Services</p>
+      <nav class="policy-nav"><a href="#privacy">Privacy</a><a href="#cookies">Cookies</a></nav>
+    </div>
+    <div class="wrap" data-lang="es">
+      <h1>Política de Privacidad y Cookies</h1>
+      <p class="subtitle">Opotek — Electronics Engineering Services</p>
+      <nav class="policy-nav"><a href="#privacy">Privacidad</a><a href="#cookies">Cookies</a></nav>
+    </div>
+  </section>
+
+  <main class="wrap">
+    <article class="content-card" data-lang="es">
+      <section id="privacy">
+        <div class="last-updated"><strong>Última actualización:</strong> Febrero de 2026</div>
+        <h2>1. Información General</h2>
+        <p>En cumplimiento del Reglamento (UE) 2016/679 del Parlamento Europeo y del Consejo, de 27 de abril de 2016 (RGPD) y la Ley Orgánica 3/2018 (LOPDGDD), le informamos sobre nuestra política de protección de datos.</p>
+        <div class="company-info">
+          <p><strong>Responsable del tratamiento:</strong> Opotek</p>
+          <p><strong>Email:</strong> opotek@protonmail.com</p>
+          <p><strong>Sitio web:</strong> https://opotek.es</p>
+        </div>
+        <h2>2. Datos que Recopilamos</h2>
+        <ul>
+          <li><strong>Datos de identificación:</strong> nombre y apellidos.</li>
+          <li><strong>Datos de contacto:</strong> correo electrónico y teléfono.</li>
+          <li><strong>Datos comerciales:</strong> empresa, sector y rol.</li>
+          <li><strong>Datos de navegación:</strong> IP, cookies e información del navegador.</li>
+          <li><strong>Datos del proyecto:</strong> especificaciones técnicas y requerimientos de ingeniería.</li>
+        </ul>
+        <h2>3. Finalidad y base jurídica</h2>
+        <p>Tratamos los datos para prestar servicios de ingeniería, atender consultas, elaborar propuestas y gestionar relaciones comerciales. La base legal es la ejecución de contrato, consentimiento, interés legítimo y obligación legal, según corresponda.</p>
+        <h2>4. Conservación y destinatarios</h2>
+        <p>Conservamos los datos durante la relación contractual y los plazos legales aplicables. Podrán acceder proveedores tecnológicos, asesores profesionales y administraciones públicas cuando exista obligación legal.</p>
+        <h2>5. Derechos</h2>
+        <p>Puede ejercer sus derechos de acceso, rectificación, supresión, oposición, limitación y portabilidad escribiendo a <strong>opotek@protonmail.com</strong>. También puede reclamar ante la AEPD (www.aepd.es).</p>
+      </section>
+
+      <section id="cookies">
+        <h2>Política de Cookies</h2>
+        <h3>1. ¿Qué son las cookies?</h3>
+        <p>Las cookies son pequeños archivos de texto que se almacenan en su dispositivo cuando visita un sitio web.</p>
+        <h3>2. Tipos de cookies utilizadas</h3>
+        <ul>
+          <li><strong>Técnicas:</strong> necesarias para el funcionamiento del sitio.</li>
+          <li><strong>Analíticas:</strong> permiten analizar el uso del sitio para mejorar contenidos y rendimiento.</li>
+          <li><strong>Preferencias:</strong> guardan ajustes como el idioma seleccionado.</li>
+        </ul>
+        <h3>3. Gestión de cookies</h3>
+        <p>Puede aceptar, bloquear o eliminar cookies mediante la configuración de su navegador. El bloqueo de determinadas cookies puede afectar a funcionalidades del sitio web.</p>
+      </section>
+    </article>
+
+    <article class="content-card" data-lang="en">
+      <section id="privacy-en">
+        <div class="last-updated"><strong>Last updated:</strong> February 2026</div>
+        <h2>1. General Information</h2>
+        <p>In compliance with Regulation (EU) 2016/679 (GDPR) and Spanish Organic Law 3/2018 (LOPDGDD), we inform you about our data protection policy.</p>
+        <div class="company-info">
+          <p><strong>Data Controller:</strong> Opotek</p>
+          <p><strong>Email:</strong> opotek@protonmail.com</p>
+          <p><strong>Website:</strong> https://opotek.es</p>
+        </div>
+        <h2>2. Data We Collect</h2>
+        <ul>
+          <li><strong>Identification data:</strong> name and surname.</li>
+          <li><strong>Contact data:</strong> email and phone number.</li>
+          <li><strong>Commercial data:</strong> company, sector, and role.</li>
+          <li><strong>Browsing data:</strong> IP address, cookies, and browser information.</li>
+          <li><strong>Project data:</strong> technical specifications and engineering requirements.</li>
+        </ul>
+        <h2>3. Purpose and legal basis</h2>
+        <p>We process data to deliver engineering services, answer inquiries, prepare proposals, and manage business relationships. Legal grounds include contract performance, consent, legitimate interest, and legal obligations, as applicable.</p>
+        <h2>4. Retention and recipients</h2>
+        <p>Data is kept during the contractual relationship and legal retention periods. Service providers, professional advisors, and public authorities may access data when legally required.</p>
+        <h2>5. Rights</h2>
+        <p>You may exercise access, rectification, erasure, objection, restriction, and portability rights by emailing <strong>opotek@protonmail.com</strong>. You can also lodge a complaint with the Spanish Data Protection Agency (www.aepd.es).</p>
+      </section>
+
+      <section id="cookies-en">
+        <h2>Cookies Policy</h2>
+        <h3>1. What are cookies?</h3>
+        <p>Cookies are small text files stored on your device when you visit a website.</p>
+        <h3>2. Types of cookies we use</h3>
+        <ul>
+          <li><strong>Technical cookies:</strong> required for core website functionality.</li>
+          <li><strong>Analytics cookies:</strong> help us understand usage and improve content and performance.</li>
+          <li><strong>Preference cookies:</strong> store settings such as selected language.</li>
+        </ul>
+        <h3>3. Cookie management</h3>
+        <p>You can allow, block, or remove cookies through browser settings. Blocking certain cookies may affect website features.</p>
+      </section>
+    </article>
+  </main>
+
+  <footer>
+    <div class="wrap" data-lang="es">© 2026 Opotek. Todos los derechos reservados.</div>
+    <div class="wrap" data-lang="en">© 2026 Opotek. All rights reserved.</div>
+  </footer>
+
+  <script>
+    const languageToggle = document.getElementById('languageToggle');
+    const backHome = document.getElementById('backHome');
+
+    function applyLanguage(lang) {
+      const isEs = lang === 'es';
+      document.documentElement.lang = isEs ? 'es' : 'en';
+      document.title = isEs ? 'Política de Privacidad y Cookies | Opotek' : 'Privacy & Cookies Policy | Opotek';
+      languageToggle.textContent = isEs ? 'EN' : 'ES';
+      backHome.textContent = isEs ? 'Inicio' : 'Home';
+      document.querySelectorAll('[data-lang]').forEach((node) => {
+        node.classList.toggle('active', node.dataset.lang === lang);
+      });
+      localStorage.setItem('opotekLang', lang);
+    }
+
+    function getInitialLanguage() {
+      const urlLang = new URLSearchParams(window.location.search).get('lang');
+      if (urlLang === 'es' || urlLang === 'en') return urlLang;
+      return localStorage.getItem('opotekLang') || 'en';
+    }
+
+    languageToggle.addEventListener('click', () => {
+      const current = localStorage.getItem('opotekLang') || 'en';
+      applyLanguage(current === 'es' ? 'en' : 'es');
+    });
+
+    applyLanguage(getInitialLanguage());
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single, accessible page that contains both the Privacy Policy and Cookies Policy in Spanish and English so users can view policies in their selected language. 
- Ensure footer policy links open the policy page in the currently selected language and allow URL override using `?lang=`.

### Description
- Added a new `policy.html` that contains the Privacy Policy and Cookies Policy content in both Spanish and English, with language blocks toggled by `data-lang` and a simple CSS layout consistent with the site. 
- Implemented language selection logic in `policy.html` that prefers `?lang=es|en` when present and otherwise falls back to `localStorage` (using `getInitialLanguage()` and `applyLanguage()`).
- Updated `index.html` footer links to point to the new `policy.html` and added dynamic `href` updates in the existing language script so the Privacy and Cookies links use the active language (`policy.html?lang=${lang}#privacy` and `#cookies`).
- Kept link anchors (`#privacy`, `#cookies`) and back navigation (`backHome`) so the policies are directly addressable and retain the site navigation controls.

### Testing
- Ran `git diff --check` to validate the working tree; no whitespace or diff-check issues were reported and changes were staged. (success)
- Served the site locally with `python3 -m http.server 4173` and verified `policy.html?lang=es` returned HTTP 200 while assets loaded; the server run produced expected responses. (success)
- Captured a full-page screenshot of the Spanish policy using Playwright (Firefox) to confirm rendering and language toggle behavior. (success)
- Attempted to run the same Playwright flow with Chromium but the Chromium binary crashed in this environment (SIGSEGV); the Firefox run provided the required validation instead. (warning)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a43e30bc8325b4e38514312c2b91)